### PR TITLE
fix: Add arm platform for M series Macs, and as supported upstream

### DIFF
--- a/.github/workflows/build-main.yaml
+++ b/.github/workflows/build-main.yaml
@@ -26,5 +26,6 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: .
+        platforms: linux/amd64,linux/arm64
         push: true
         tags: ghcr.io/${{ github.repository }}/laa-clamav:latest


### PR DESCRIPTION
Single line change to GitHub action. Arm platform is supported by the upstream image, and is needed for local builds using newer Macs.